### PR TITLE
feat: particles amount spawn depending on portal width

### DIFF
--- a/rsclone/src/js/sprites/portal.js
+++ b/rsclone/src/js/sprites/portal.js
@@ -70,9 +70,9 @@ export default class Portal extends Phaser.GameObjects.Rectangle {
     this.emitter = this.particle.createEmitter({
       x,
       y,
-      lifespan: 4000,
+      lifespan: width * 12 + 1700,
       angle: { min: 0, max: 360 },
-      speed: { min: 20, max: 50 },
+      speed: { min: 20, max: 70 },
       scale: { min: 0.25, max: 1 },
       bounce: 0.8,
       bounds: emitterBounds,


### PR DESCRIPTION
Количество частиц в порталах зависит от продолжительности жизни частиц(lifespan). Для стандартного портала была подобрана величина 4000мс, что на 186пх длины портала давало нужный визуал. Линейная зависимость без постоянной составляющей нам не походит, т.к. на маленьких порталах будет слишком короткий lifespan, значит надо добавлять постоянную составляющую.
В общем я пытался поиграть с коэффициентами - получилось не лучшим образом, т.к. мелкие порталы все-равно остались перегружены, но, хотя бы, для всех размеров порталов четко видны их границы. Если есть желание - в перспективе можно пересмотреть эту формулу, у меня пока не выходит сделать лучше.